### PR TITLE
Correct a typo

### DIFF
--- a/blog_posts/eslint-refactor-for-in.md
+++ b/blog_posts/eslint-refactor-for-in.md
@@ -31,7 +31,7 @@ Object.keys(data).forEach(k => console.log(k));
 ```js
 const data = [3, 4];
 // Iterate over the values
-Object.keys(data).forEach(v => console.log(v));
+Object.values(data).forEach(v => console.log(v));
 // 3 4
 ```
 


### PR DESCRIPTION
Corrected a typo, `Object.keys` was used to iterate over the values instead of `Object.values` 