### PR TITLE
fix  semantic error in javascript-closures

### DIFF
--- a/blog_posts/javascript-closures.md
+++ b/blog_posts/javascript-closures.md
@@ -35,7 +35,7 @@ const initCounter = (start = 0) => {
     get: () => value,
     increment: () => ++value,
     decrement: () => --value,
-    reset: () => start
+    reset: () => value = start
   };
 }
 


### PR DESCRIPTION
Adjust initCounter's returned reset method to fit the idea it's trying to illustrate, of resetting the counter value